### PR TITLE
adding support for environment variables in config file

### DIFF
--- a/agent/config/config_file.go
+++ b/agent/config/config_file.go
@@ -128,7 +128,12 @@ func NewConfigFile() (*File, error) {
 		return nil, fmt.Errorf("Unable to open configuration file at %s. Did you use --config to specify the right path?\n\n", filePath)
 	}
 
-	_, err = toml.Decode(string(source), result)
+	// replace environment variables in config file
+	// NOTE: this is not part of the TOML standard, so we need to deal with this
+	//       before the TOML decode takes place
+	sourceExpanded := os.ExpandEnv(string(source))
+
+	_, err = toml.Decode(string(sourceExpanded), result)
 
 	for _, job := range result.FlowField {
 		result.JobsField = append(result.JobsField, job)


### PR DESCRIPTION
Hi @andblack ,

As discussed yesterday, this adds support for using environment variables in the config file. I was pretty surprised myself that this is a 2 line fix. It is replacing environment variables before handing it to the toml decoder.

Cheers
Marcus