### PR TITLE
Support for Mongo SSL connections

### DIFF
--- a/agent/lua/library_mongo_connection.go
+++ b/agent/lua/library_mongo_connection.go
@@ -1,6 +1,16 @@
 package lua
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"io/ioutil"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/telemetryapp/go-lua"
 	"github.com/telemetryapp/goluago/util"
 	"gopkg.in/mgo.v2"
@@ -57,7 +67,13 @@ var mongoConnectionFunctions = map[string]func(s *mgo.Session) lua.Function{
 }
 
 func pushGoConnection(l *lua.State, connectionString string) {
-	s, err := mgo.Dial(connectionString)
+	ci, err := parseMongoURI(connectionString)
+	if err != nil {
+		lua.Errorf(l, "%s", err.Error())
+	}
+
+	//s, err := mgo.Dial(connectionString)
+	s, err := mgo.DialWithInfo(ci)
 
 	if err != nil {
 		lua.Errorf(l, "%s", err.Error())
@@ -78,4 +94,121 @@ func pushGoConnection(l *lua.State, connectionString string) {
 	})
 	l.SetField(-2, "__gc")
 	l.SetMetaTable(-2)
+}
+
+func parseMongoURI(rawURI string) (*mgo.DialInfo, error) {
+	uri, err := url.Parse(rawURI)
+	if err != nil {
+		return nil, err
+	}
+
+	info := mgo.DialInfo{
+		Addrs:    strings.Split(uri.Host, ","),
+		Database: strings.TrimPrefix(uri.Path, "/"),
+		Timeout:  10 * time.Second,
+	}
+
+	if uri.User != nil {
+		info.Username = uri.User.Username()
+		info.Password, _ = uri.User.Password()
+	}
+
+	uriSsl := false
+	var sslKeyPath, sslCertPath, sslCAPath string
+	uriSslSkipVerify := false
+
+	query := uri.Query()
+	for key, values := range query {
+		var value string
+		if len(values) > 0 {
+			value = values[0]
+		}
+
+		switch key {
+		case "authSource":
+			info.Source = value
+		case "authMechanism":
+			info.Mechanism = value
+		case "gssapiServiceName":
+			info.Service = value
+		case "replicaSet":
+			info.ReplicaSetName = value
+		case "maxPoolSize":
+			poolLimit, err := strconv.Atoi(value)
+			if err != nil {
+				return nil, errors.New("bad value for maxPoolSize: " + value)
+			}
+			info.PoolLimit = poolLimit
+		case "ssl":
+			ssl, err := strconv.ParseBool(value)
+			if err != nil {
+				return nil, errors.New("bad value for ssl: " + value)
+			}
+			if ssl {
+				uriSsl = true
+			}
+		case "sslSkipVerify":
+			sslSkipVerify, err := strconv.ParseBool(value)
+			if err != nil {
+				return nil, errors.New("bad value for sslSkipVerify: " + value)
+			}
+			if sslSkipVerify {
+				uriSslSkipVerify = true
+			}
+		case "sslKey":
+			sslKeyPath = value
+		case "sslCert":
+			sslCertPath = value
+		case "sslCA":
+			sslCAPath = value
+		case "connect":
+			if value == "direct" {
+				info.Direct = true
+				break
+			}
+			if value == "replicaSet" {
+				break
+			}
+			fallthrough
+		default:
+			return nil, errors.New("unsupported connection URL option: " + key + "=" + value)
+		}
+	}
+
+	// deal with TLS
+	if uriSsl {
+		tlsConfig := tls.Config{}
+
+		if uriSslSkipVerify {
+			tlsConfig.InsecureSkipVerify = true
+		}
+
+		if sslCAPath != "" {
+			caBytes, err := ioutil.ReadFile(sslCAPath)
+			if err != nil {
+				return nil, errors.New("could not read CA data from '" + sslCAPath + "'")
+			}
+			caPool := x509.NewCertPool()
+			ok := caPool.AppendCertsFromPEM(caBytes)
+			if !ok {
+				// TODO: log something?
+			}
+			tlsConfig.RootCAs = caPool
+		}
+
+		if sslKeyPath != "" && sslCertPath != "" {
+			cert, err := tls.LoadX509KeyPair(sslCertPath, sslKeyPath)
+			if err != nil {
+				return nil, errors.New("could not load cert and/or key from '" + sslCertPath + " / '" + sslKeyPath + "'")
+			}
+
+			tlsConfig.Certificates = []tls.Certificate{cert}
+		}
+
+		info.DialServer = func(addr *mgo.ServerAddr) (net.Conn, error) {
+			return tls.Dial("tcp", addr.String(), &tlsConfig)
+		}
+	}
+
+	return &info, nil
 }


### PR DESCRIPTION
This adds support for Mongo SSL connections from the telemetry agent. The following parameters can be passed in the Mongo connection URI to use SSL:
- ssl (bool) - activates/deactivates SSL
- sslSkipVerify (bool) - disables certificate validation when true
- sslKey - path to key used for SSL client authentication (SSL client authentication will be used when this is set)
- sslCert - path to cert use for SSL client authentication (SSL client authentication will be used when this is set)
- sslCA - path to file containing all CA certificates for server verification

Example of a Mongo URI:
`mongodb://USER:PASSWORD@server1:27017,server2:2017,server3:27017/?ssl=true&sslKey=/etc/mongo/tls/tls.key&sslCert=/etc/mongo/tls/tls.crt&sslCA=/etc/mongo/ca/ca.crt`