### PR TITLE
initial http TLS settings support

### DIFF
--- a/agent/lua/library_http.go
+++ b/agent/lua/library_http.go
@@ -2,8 +2,12 @@ package lua
 
 import (
 	"bytes"
+	"crypto/tls"
+	"crypto/x509"
 	"io/ioutil"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/telemetryapp/go-lua"
 	"github.com/telemetryapp/goluago/util"
@@ -42,11 +46,38 @@ var httpLibrary = []lua.RegistryFunction{
 				}
 			}
 
+			// see if there is another table in the arguments, and extract the TLS
+			// information from there
+			useTLS := false
+			var tlsConfig *tls.Config
+
+			argIndex++
+			if l.IsTable(argIndex) {
+				useTLS = true
+				var tlsSettings map[string]string
+				tlsSettings, err = util.PullStringTable(l, argIndex)
+				if err != nil {
+					lua.Errorf(l, "Error reading TLS Settings table: %s", err.Error())
+				}
+				tlsConfig = tlsConfigFromLuaTable(l, tlsSettings)
+			}
+
+			var client *http.Client
+			if useTLS {
+				client = &http.Client{
+					Transport: &http.Transport{
+						TLSClientConfig: tlsConfig,
+					},
+				}
+			} else {
+				client = http.DefaultClient
+			}
+
 			if len(username) > 0 || len(password) > 0 {
 				req.SetBasicAuth(username, password)
 			}
 
-			resp, err := http.DefaultClient.Do(req)
+			resp, err := client.Do(req)
 			if err != nil {
 				lua.Errorf(l, "%s", err.Error())
 			}
@@ -97,11 +128,38 @@ var httpLibrary = []lua.RegistryFunction{
 				}
 			}
 
+			// see if there is another table in the arguments, and extract the TLS
+			// information from there
+			useTLS := false
+			var tlsConfig *tls.Config
+
+			argIndex++
+			if l.IsTable(argIndex) {
+				useTLS = true
+				var tlsSettings map[string]string
+				tlsSettings, err = util.PullStringTable(l, argIndex)
+				if err != nil {
+					lua.Errorf(l, "Error reading TLS Settings table: %s", err.Error())
+				}
+				tlsConfig = tlsConfigFromLuaTable(l, tlsSettings)
+			}
+
+			var client *http.Client
+			if useTLS {
+				client = &http.Client{
+					Transport: &http.Transport{
+						TLSClientConfig: tlsConfig,
+					},
+				}
+			} else {
+				client = http.DefaultClient
+			}
+
 			if len(username) > 0 || len(password) > 0 {
 				req.SetBasicAuth(username, password)
 			}
 
-			resp, err := http.DefaultClient.Do(req)
+			resp, err := client.Do(req)
 			if err != nil {
 				lua.Errorf(l, "%s", err.Error())
 			}
@@ -163,11 +221,38 @@ var httpLibrary = []lua.RegistryFunction{
 				}
 			}
 
+			// see if there is another table in the arguments, and extract the TLS
+			// information from there
+			useTLS := false
+			var tlsConfig *tls.Config
+
+			argIndex++
+			if l.IsTable(argIndex) {
+				useTLS = true
+				var tlsSettings map[string]string
+				tlsSettings, err = util.PullStringTable(l, argIndex)
+				if err != nil {
+					lua.Errorf(l, "Error reading TLS Settings table: %s", err.Error())
+				}
+				tlsConfig = tlsConfigFromLuaTable(l, tlsSettings)
+			}
+
+			var client *http.Client
+			if useTLS {
+				client = &http.Client{
+					Transport: &http.Transport{
+						TLSClientConfig: tlsConfig,
+					},
+				}
+			} else {
+				client = http.DefaultClient
+			}
+
 			if len(username) > 0 || len(password) > 0 {
 				req.SetBasicAuth(username, password)
 			}
 
-			resp, err := http.DefaultClient.Do(req)
+			resp, err := client.Do(req)
 			if err != nil {
 				lua.Errorf(l, "%s", err.Error())
 			}
@@ -184,6 +269,130 @@ var httpLibrary = []lua.RegistryFunction{
 			return 1
 		},
 	},
+}
+
+func tlsConfigFromLuaTable(l *lua.State, tlsSettings map[string]string) *tls.Config {
+	var tlsKeyPath, tlsCertPath string
+	var tlsConfig tls.Config
+	for key, value := range tlsSettings {
+		switch key {
+		case "InsecureSkipVerify":
+			v, err := strconv.ParseBool(value)
+			if err != nil {
+				lua.Errorf(l, "Error in TLS Settings for '%s': %s", key, err.Error())
+			}
+			tlsConfig.InsecureSkipVerify = v
+		case "SessionTicketsDisabled":
+			v, err := strconv.ParseBool(value)
+			if err != nil {
+				lua.Errorf(l, "Error in TLS Settings for '%s': %s", key, err.Error())
+			}
+			tlsConfig.SessionTicketsDisabled = v
+		case "PreferServerCipherSuites":
+			v, err := strconv.ParseBool(value)
+			if err != nil {
+				lua.Errorf(l, "Error in TLS Settings for '%s': %s", key, err.Error())
+			}
+			tlsConfig.PreferServerCipherSuites = v
+		case "MinVersion":
+			switch value {
+			case "VersionSSL30":
+				tlsConfig.MinVersion = tls.VersionSSL30
+			case "VersionTLS10":
+				tlsConfig.MinVersion = tls.VersionTLS10
+			case "VersionTLS11":
+				tlsConfig.MinVersion = tls.VersionTLS11
+			case "VersionTLS12":
+				tlsConfig.MinVersion = tls.VersionTLS12
+			default:
+				lua.Errorf(l, "Error in TLS Settings for '%s': value '%s' is not an accepted value", key, value)
+			}
+		case "MaxVersion":
+			switch value {
+			case "VersionSSL30":
+				tlsConfig.MaxVersion = tls.VersionSSL30
+			case "VersionTLS10":
+				tlsConfig.MaxVersion = tls.VersionTLS10
+			case "VersionTLS11":
+				tlsConfig.MaxVersion = tls.VersionTLS11
+			case "VersionTLS12":
+				tlsConfig.MaxVersion = tls.VersionTLS12
+			default:
+				lua.Errorf(l, "Error in TLS Settings for '%s': value '%s' is not an accepted value", key, value)
+			}
+		case "CipherSuites":
+			var clientSupportedCiphers []uint16
+			for _, cipher := range strings.Split(value, ",") {
+				switch cipher {
+				case "TLS_RSA_WITH_RC4_128_SHA":
+					clientSupportedCiphers = append(clientSupportedCiphers, tls.TLS_RSA_WITH_RC4_128_SHA)
+				case "TLS_RSA_WITH_3DES_EDE_CBC_SHA":
+					clientSupportedCiphers = append(clientSupportedCiphers, tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA)
+				case "TLS_RSA_WITH_AES_128_CBC_SHA":
+					clientSupportedCiphers = append(clientSupportedCiphers, tls.TLS_RSA_WITH_AES_128_CBC_SHA)
+				case "TLS_RSA_WITH_AES_256_CBC_SHA":
+					clientSupportedCiphers = append(clientSupportedCiphers, tls.TLS_RSA_WITH_AES_256_CBC_SHA)
+				case "TLS_RSA_WITH_AES_128_GCM_SHA256":
+					clientSupportedCiphers = append(clientSupportedCiphers, tls.TLS_RSA_WITH_AES_128_GCM_SHA256)
+				case "TLS_RSA_WITH_AES_256_GCM_SHA384":
+					clientSupportedCiphers = append(clientSupportedCiphers, tls.TLS_RSA_WITH_AES_256_GCM_SHA384)
+				case "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA":
+					clientSupportedCiphers = append(clientSupportedCiphers, tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA)
+				case "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA":
+					clientSupportedCiphers = append(clientSupportedCiphers, tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA)
+				case "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA":
+					clientSupportedCiphers = append(clientSupportedCiphers, tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA)
+				case "TLS_ECDHE_RSA_WITH_RC4_128_SHA":
+					clientSupportedCiphers = append(clientSupportedCiphers, tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA)
+				case "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA":
+					clientSupportedCiphers = append(clientSupportedCiphers, tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA)
+				case "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":
+					clientSupportedCiphers = append(clientSupportedCiphers, tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)
+				case "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":
+					clientSupportedCiphers = append(clientSupportedCiphers, tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA)
+				case "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":
+					clientSupportedCiphers = append(clientSupportedCiphers, tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)
+				case "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256":
+					clientSupportedCiphers = append(clientSupportedCiphers, tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)
+				case "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":
+					clientSupportedCiphers = append(clientSupportedCiphers, tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384)
+				case "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384":
+					clientSupportedCiphers = append(clientSupportedCiphers, tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384)
+				default:
+					lua.Errorf(l, "Error in TLS Settings for '%s': '%s' is not an accepted cipher", key, cipher)
+				}
+			}
+		case "RootCAs":
+			caBytes, err := ioutil.ReadFile(value)
+			if err != nil {
+				lua.Errorf(l, "Error in TLS Settings for '%s': could not read CA data from '%s': %s", key, value, err.Error())
+			}
+			caPool := x509.NewCertPool()
+			ok := caPool.AppendCertsFromPEM(caBytes)
+			if !ok {
+				lua.Errorf(l, "Error in TLS Settings for '%s': could not append certs to root CA pool: %s", key, err.Error())
+			}
+			tlsConfig.RootCAs = caPool
+		case "certFile":
+			tlsCertPath = value
+		case "keyFile":
+			tlsKeyPath = value
+		default:
+			// TODO: print something
+		}
+	}
+
+	// we can set these only after we parsed both paths from the table
+	if tlsKeyPath != "" && tlsCertPath != "" {
+		cert, err := tls.LoadX509KeyPair(tlsCertPath, tlsKeyPath)
+		if err != nil {
+			lua.Errorf(l, "Error in TLS Settings: could not load cert and/or key from '%s' / '%s': %s", tlsCertPath, tlsKeyPath, err.Error())
+		}
+
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+
+	return &tlsConfig
 }
 
 func openHTTPLibrary(l *lua.State) {


### PR DESCRIPTION
Adds support for optional configuration of TLS client settings for HTTP requests. This is useful e.g. if you try to query https URLs which run a server which uses certificates from a custom / own CA, or if you need to do TLS client authentication.

The functionality has been added in the following way: it allows to pass an optional last parameter to the `http.get`, `http.post` and `http.custom` Lua functions, and it checks for a Lua table there. The Lua table **must be** a complete string table (both keys and values must be strings), and it allows for the following options. **NOTE:** all options are optional, and will default to the _golang_ defaults if not specified here:
- **RootCAs**: path to a file containing concatenated PEM encoded CA certificates against which the client validates the servers identity
- **certFile**: path to a file containing the PEM encoded ceritificate to be used for TLS client authentication
- **keyFile**: path to a file containing the PEM encoded key to be used for TLS client authentication
- **InsecureSkipVerify**: (bool, but must be passed as string) enables/disables certificate verification
- **SessionTicketsDisabled**: (bool, but must be passed as string) enables/disables the use of TLS session tickets for session resumption in the client
- **PreferServerCipherSuites**: (bool, but must be passed as string): enables/disables the request for preferring the server's cipher suites over the list provided by the client
- **MinVersion**: possible values: VersionSSL30, VersionTLS10, VersionTLS11, VersionTLS12 ... the minimum version of SSL/TLS the client will support
- **MaxVersion**: possible values: VersionSSL30, VersionTLS10, VersionTLS11, VersionTLS12 ... the maximum version of SSL/TLS the client will support
- **CipherSuites**: a _comma separated list_ of supported cipher suites that the client will send in its hello to the server. The possible values are:
  - TLS_RSA_WITH_RC4_128_SHA 
  - TLS_RSA_WITH_3DES_EDE_CBC_SHA  
  - TLS_RSA_WITH_AES_128_CBC_SHA            
  - TLS_RSA_WITH_AES_256_CBC_SHA           
  - TLS_RSA_WITH_AES_128_GCM_SHA256     
  - TLS_RSA_WITH_AES_256_GCM_SHA384    
  - TLS_ECDHE_ECDSA_WITH_RC4_128_SHA       
  - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA 
  - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA    
  - TLS_ECDHE_RSA_WITH_RC4_128_SHA       
  - TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA   
  - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA      
  - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA    
  - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 
  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 
  - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 
  - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 